### PR TITLE
Cr129 adding test helper validation methods

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/TestHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/TestHelper.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ctp.common;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.time.ZoneOffset;
@@ -48,14 +50,16 @@ public class TestHelper {
     ZonedDateTime compareDate = zdt.withZoneSameInstant(ZoneOffset.systemDefault());
     return formatter.format(compareDate);
   }
-  
+
   /**
    * Validates that a dateTime string is formatted as: "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
-   * 
+   *
    * @param dateTimeAsString is a string containing a dataTime value to check.
-   * @throws AssertionError if the supplied dateTime string is not in the correct time format.
+   * @throws AssertionError if the supplied dateTime string is null or in the correct time format.
    */
   public static void validateAsDateTime(String dateTimeAsString) {
+    assertNotNull("datetime cannot be null", dateTimeAsString);
+
     String dateTimePattern = DateTimeUtil.DATE_FORMAT_IN_JSON;
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern);
     try {
@@ -66,16 +70,17 @@ public class TestHelper {
   }
 
   /**
-   * Validates that the supplied string is in UUID format.
-   * If the string 
-   * 
+   * Validates that the supplied string is in UUID format. If the string
+   *
    * @param uuidAsString is the string to check.
-   * @throws AssertionError if the string can not in UUID format. 
+   * @throws AssertionError if the string is null or not in UUID format.
    */
   public static void validateAsUUID(String uuidAsString) {
+    assertNotNull("uuid cannot be null", uuidAsString);
+
     try {
       UUID.fromString(uuidAsString);
-    } catch (IllegalArgumentException e) { 
+    } catch (IllegalArgumentException e) {
       fail("String is not in UUID format: " + uuidAsString);
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/common/TestHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/TestHelper.java
@@ -1,10 +1,14 @@
 package uk.gov.ons.ctp.common;
 
+import static org.junit.Assert.fail;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+import uk.gov.ons.ctp.common.time.DateTimeUtil;
 
 /** Some individual methods for unit tests to reuse */
 public class TestHelper {
@@ -43,5 +47,36 @@ public class TestHelper {
     ZonedDateTime zdt = ZonedDateTime.parse(date, formatter);
     ZonedDateTime compareDate = zdt.withZoneSameInstant(ZoneOffset.systemDefault());
     return formatter.format(compareDate);
+  }
+  
+  /**
+   * Validates that a dateTime string is formatted as: "yyyy-MM-dd'T'HH:mm:ss.SSSZ".
+   * 
+   * @param dateTimeAsString is a string containing a dataTime value to check.
+   * @throws AssertionError if the supplied dateTime string is not in the correct time format.
+   */
+  public static void validateAsDateTime(String dateTimeAsString) {
+    String dateTimePattern = DateTimeUtil.DATE_FORMAT_IN_JSON;
+    DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimePattern);
+    try {
+      dateTimeFormatter.parse(dateTimeAsString);
+    } catch (DateTimeParseException e) {
+      fail("String is not in date time format: " + dateTimeAsString);
+    }
+  }
+
+  /**
+   * Validates that the supplied string is in UUID format.
+   * If the string 
+   * 
+   * @param uuidAsString is the string to check.
+   * @throws AssertionError if the string can not in UUID format. 
+   */
+  public static void validateAsUUID(String uuidAsString) {
+    try {
+      UUID.fromString(uuidAsString);
+    } catch (IllegalArgumentException e) { 
+      fail("String is not in UUID format: " + uuidAsString);
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/TestHelperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/TestHelperTest.java
@@ -1,0 +1,38 @@
+package uk.gov.ons.ctp.common;
+
+import org.junit.Test;
+
+public class TestHelperTest {
+
+  @Test
+  public void testValidateAsDateTimeWithValidDateTime() {
+    TestHelper.validateAsDateTime("2019-04-10T15:32:38.941+0100");
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testValidateAsDateTimeWithNullDateTime() {
+    TestHelper.validateAsDateTime(null);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testValidateAsDateTimeWithInvalidDateTime() {
+    TestHelper.validateAsDateTime("2019-04-10T15:32pm");
+  }
+
+  @Test
+  public void testValidateAsUUIDValid() {
+    String uuid = "4c2cad7f-a942-4fe8-a04e-8d0fbd99f462";
+    TestHelper.validateAsUUID(uuid);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testValidateAsUUIDNull() {
+    TestHelper.validateAsUUID(null);
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testValidateAsUUIDInvalid() {
+    String uuid = "2344-234234";
+    TestHelper.validateAsUUID(uuid);
+  }
+}


### PR DESCRIPTION
# Motivation and Context
This pull request is for the addition of a 2 test utility methods:

1. Validate that a string is in the 'standard' json datetime format.
2. Validate that a string is parsable as a UUID.

I've also added unit tests for these methods.

# How to test?
Run all unit tests.

# Links
This is part of CR129: https://collaborate2.ons.gov.uk/jira/browse/CR-129