### PR TITLE
CR-347 Moved Firestore wait logic from EventGenerator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>unirest-java</artifactId>
       <version>1.4.9</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-firestore</artifactId>
+      <version>1.6.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
@@ -1,0 +1,91 @@
+package uk.gov.ons.ctp.common.firestore;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.FieldPath;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+/**
+ * This class is responsible for communication with Firestore.
+ * 
+ * It runs as a singleton so that it can reuse it's Firestore connection.
+ */
+class FirestoreService {
+  private static final Logger log = LoggerFactory.getLogger(FirestoreService.class);
+
+  private static FirestoreService instance = new FirestoreService();
+  
+  private Firestore firestore;
+  private String gcpProject;
+
+  public static synchronized FirestoreService instance() {
+    return instance;
+  }
+  
+  private FirestoreService() {
+    firestore = FirestoreOptions.getDefaultInstance().getService();
+
+    gcpProject = firestore.getOptions().getProjectId();
+    log.info("Connected to Firestore project: " + gcpProject);
+  }
+
+  public long objectExists(
+      String collectionName,
+      String key,
+      Long newerThan,
+      String contentCheckPath,
+      String expectedValue)
+      throws CTPException {
+    // Run a query
+    String schema = gcpProject + "-" + collectionName;
+    FieldPath fieldPathForId = FieldPath.documentId();
+    ApiFuture<QuerySnapshot> query =
+        firestore.collection(schema).whereEqualTo(fieldPathForId, key).get();
+
+    // Wait for query to complete and get results
+    QuerySnapshot querySnapshot;
+    try {
+      querySnapshot = query.get();
+    } catch (Exception e) {
+      String failureMessage =
+          "Exception caught whilst attempting to find object in schema '" + schema + "' for key '" + key + "'";
+      log.error(e, failureMessage);
+      throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
+    }
+
+    // Bail out if nothing found
+    if (querySnapshot.isEmpty()) {
+      return -1;
+    }
+
+    // Get hold of candidate object
+    QueryDocumentSnapshot targetDocument = querySnapshot.getDocuments().get(0);
+    long objectUpdateMillis = targetDocument.getUpdateTime().toDate().getTime();
+
+    // Optionally, only regard the object as existing if it is newer than the specified time
+    if (newerThan != null) {
+      if (!(objectUpdateMillis > newerThan)) {
+        return -1;
+      }
+    }
+
+    // Optionally, determine if named field is in the expected state
+    if (contentCheckPath != null) {
+      String[] parts = contentCheckPath.split("\\.");
+      FieldPath fieldPath = FieldPath.of(parts);
+      Object actualValue = targetDocument.get(fieldPath);
+
+      if (!expectedValue.equals(actualValue)) {
+        return -1;
+      }
+    }
+
+    return objectUpdateMillis;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
@@ -13,21 +13,21 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 
 /**
  * This class is responsible for communication with Firestore.
- * 
- * It runs as a singleton so that it can reuse it's Firestore connection.
+ *
+ * <p>It runs as a singleton so that it can reuse it's Firestore connection.
  */
 class FirestoreService {
   private static final Logger log = LoggerFactory.getLogger(FirestoreService.class);
 
   private static FirestoreService instance = new FirestoreService();
-  
+
   private Firestore firestore;
   private String gcpProject;
 
   public static synchronized FirestoreService instance() {
     return instance;
   }
-  
+
   private FirestoreService() {
     firestore = FirestoreOptions.getDefaultInstance().getService();
 
@@ -54,7 +54,11 @@ class FirestoreService {
       querySnapshot = query.get();
     } catch (Exception e) {
       String failureMessage =
-          "Exception caught whilst attempting to find object in schema '" + schema + "' for key '" + key + "'";
+          "Exception caught whilst attempting to find object in schema '"
+              + schema
+              + "' for key '"
+              + key
+              + "'";
       log.error(e, failureMessage);
       throw new CTPException(Fault.SYSTEM_ERROR, e, failureMessage);
     }

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreService.java
@@ -80,7 +80,7 @@ class FirestoreService {
     }
 
     // Optionally, determine if named field is in the expected state
-    if (contentCheckPath != null) {
+    if (contentCheckPath != null && expectedValue != null) {
       String[] parts = contentCheckPath.split("\\.");
       FieldPath fieldPath = FieldPath.of(parts);
       Object actualValue = targetDocument.get(fieldPath);

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
@@ -38,10 +38,9 @@ public class FirestoreWait {
   // This is the value that a field must contain if 'contentCheckPath' has been specified.
   private String expectedValue;
 
-  // This specifies how long the caller is prepared to wait for an object to appear in
-  // Firestore. This string must end with either a 'ms' suffix for milliseconds or 's' for
-  // seconds, eg, '750ms', '10s or '2.5s'.
-  @NonNull private String timeout;
+  // This specifies the number of milliseconds that the caller is prepared to wait for an object
+  // to appear in Firestore.
+  @NonNull private Long timeout;
 
   /**
    * This method allows the caller to wait for an object to appear in Firestore. If the object is
@@ -59,8 +58,7 @@ public class FirestoreWait {
    */
   public Long waitForObject() throws CTPException {
     final long startTime = System.currentTimeMillis();
-    final long timeoutMillis = parseTimeoutString(timeout);
-    final long timeoutLimit = startTime + timeoutMillis;
+    final long timeoutLimit = startTime + timeout;
 
     log.info(
         "Firestore wait. Looking for for collection '"
@@ -124,26 +122,5 @@ public class FirestoreWait {
     }
 
     return objectUpdateTimestamp;
-  }
-
-  private long parseTimeoutString(String timeout) throws CTPException {
-    int multiplier;
-    if (timeout.endsWith("ms")) {
-      multiplier = 1;
-    } else if (timeout.endsWith("s")) {
-      multiplier = 1000;
-    } else {
-      String errorMessage =
-          "timeout specification ('"
-              + timeout
-              + "') must end with either 'ms' for milliseconds or 's' for seconds";
-      log.error(errorMessage);
-      throw new CTPException(Fault.VALIDATION_FAILED, errorMessage);
-    }
-
-    String timeoutValue = timeout.replaceAll("(ms|s)", "");
-
-    double timeoutAsDouble = Double.parseDouble(timeoutValue) * multiplier;
-    return (long) timeoutAsDouble;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
@@ -1,0 +1,147 @@
+package uk.gov.ons.ctp.common.firestore;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+
+
+/**
+ * This is a Firestore utility class to help test code interact with Firestore.
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FirestoreWait {
+  private static final Logger log = LoggerFactory.getLogger(FirestoreWait.class);
+
+  @NonNull
+  private String collection;
+  
+  @NonNull
+  private String key;
+  
+  private Long newerThan;
+  
+  private String contentCheckPath;
+  private String expectedValue;
+  
+  @NonNull
+  private String timeout;
+  
+  /**
+   * This method allows the caller to wait for an object to appear in Firestore. If the object is
+   * found within the timeout period then it returns with the update time of the object,
+   * otherwise it returns with null.
+   *
+   * The caller can optionally wait for an object to be updated by specifying the updated
+   * timestamp or by the content of a named field. If both criteria are specified then both
+   * conditions must be satisfied before we regard the object has having arrived in Firestore.
+   *
+   * @param collection is the name of the collection to search, eg, 'case'
+   * @param key is the key of the target object in the collection. eg,
+   *     'f868fcfc-7280-40ea-ab01-b173ac245da3'
+   * @param newerThan, is an optional argument to specify the timestamp that the an object must have
+   *     been updated after. Waiting will continue until the until the update timestamp of the
+   *     object is greater than this value, or the timeout period is reached. This value is the
+   *     number of milliseconds since the epoch.
+   * @param contentCheckPath, is an optional path to a field whose content we check to decide if an
+   *     object has been updated, eg, 'contact.forename' or 'state'. If the target object does not
+   *     contain the field with the expected value then waiting will continue until it does, or the
+   *     timeout is reached.
+   * @param expectedValue, is the value that a field must contain if 'contentCheckPath' has been
+   *     specified.
+   * @param timeout specifies how long the caller is prepared to wait for an object to appear in
+   *     Firestore. This string must end with either a 'ms' suffix for milliseconds or 's' for
+   *     seconds, eg, '750ms', '10s or '2.5s'.
+   * @return The update timestamp of a found object, or null if not found within the timeout.
+   * @throws CTPException in the event of a failure being detected. This will be of type Fault.VALIDATION_FAILED
+   * if any arguments fail validation, or type Fault.SYSTEM_ERROR if there is a Firestore exception. 
+   */
+  public Long waitForObject() throws CTPException {
+    long startTime = System.currentTimeMillis();
+    long timeoutMillis = parseTimeoutString(timeout);
+    long timeoutLimit = startTime + timeoutMillis;
+
+    log.info(
+        "Firestore wait. Looking for for collection '"
+            + collection
+            + "' to contain '"
+            + key
+            + "' "
+            + "for up to '"
+            + timeout
+            + "'");
+    
+    if (newerThan != null) {
+      log.info("Firestore wait. Update timestamp must be newer than '" + newerThan + "'");
+    } else {
+      log.info("Firestore wait. Not waiting on object update timestamp");
+    }
+
+    if (contentCheckPath != null) {
+      log.info("Firestore wait. Content of '" + contentCheckPath + "' to contain '" + expectedValue + "'");
+    } else {
+      log.info("Firestore wait. Not waiting on object state");
+    }
+    
+    // Validate matching path+value arguments
+    if (contentCheckPath != null ^ expectedValue != null) {
+      String errorMessage =
+          "Mismatched 'path' and 'value' arguments."
+              + " Either both must be supplied or neither supplied";
+      log.error(errorMessage);
+      throw new CTPException(Fault.VALIDATION_FAILED, errorMessage);
+    }
+
+    // Wait until the object appears in Firestore, or we timeout waiting
+    boolean found = false;
+    long objectUpdateTimestamp;
+    do {
+      objectUpdateTimestamp =
+          FirestoreService.instance().objectExists(
+              collection, key, newerThan, contentCheckPath, expectedValue);
+      if (objectUpdateTimestamp > 0) {
+        log.debug("Found object");
+        found = true;
+        break;
+      }
+
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        break;
+      }
+    } while (System.currentTimeMillis() < timeoutLimit);
+
+    if (!found) {
+      log.debug("Failed to find object");
+      return null;
+    }
+
+    return objectUpdateTimestamp;
+  }
+  
+  
+  private long parseTimeoutString(String timeout) throws CTPException {
+    int multiplier;
+    if (timeout.endsWith("ms")) {
+      multiplier = 1;
+    } else if (timeout.endsWith("s")) {
+      multiplier = 1000;
+    } else {
+      String errorMessage = "timeout specification ('" + timeout + "') must end with either 'ms' for milliseconds or 's' for seconds";
+      log.error(errorMessage);
+      throw new CTPException(Fault.VALIDATION_FAILED, errorMessage);
+    }
+
+    String timeoutValue = timeout.replaceAll("(ms|s)", "");
+
+    double timeoutAsDouble = Double.parseDouble(timeoutValue) * multiplier;
+    return (long) timeoutAsDouble;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
@@ -9,36 +9,30 @@ import lombok.NonNull;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 
-
-/**
- * This is a Firestore utility class to help test code interact with Firestore.
- */
+/** This is a Firestore utility class to help test code interact with Firestore. */
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class FirestoreWait {
   private static final Logger log = LoggerFactory.getLogger(FirestoreWait.class);
 
-  @NonNull
-  private String collection;
-  
-  @NonNull
-  private String key;
-  
+  @NonNull private String collection;
+
+  @NonNull private String key;
+
   private Long newerThan;
-  
+
   private String contentCheckPath;
   private String expectedValue;
-  
-  @NonNull
-  private String timeout;
-  
+
+  @NonNull private String timeout;
+
   /**
    * This method allows the caller to wait for an object to appear in Firestore. If the object is
-   * found within the timeout period then it returns with the update time of the object,
-   * otherwise it returns with null.
+   * found within the timeout period then it returns with the update time of the object, otherwise
+   * it returns with null.
    *
-   * The caller can optionally wait for an object to be updated by specifying the updated
+   * <p>The caller can optionally wait for an object to be updated by specifying the updated
    * timestamp or by the content of a named field. If both criteria are specified then both
    * conditions must be satisfied before we regard the object has having arrived in Firestore.
    *
@@ -59,8 +53,9 @@ public class FirestoreWait {
    *     Firestore. This string must end with either a 'ms' suffix for milliseconds or 's' for
    *     seconds, eg, '750ms', '10s or '2.5s'.
    * @return The update timestamp of a found object, or null if not found within the timeout.
-   * @throws CTPException in the event of a failure being detected. This will be of type Fault.VALIDATION_FAILED
-   * if any arguments fail validation, or type Fault.SYSTEM_ERROR if there is a Firestore exception. 
+   * @throws CTPException in the event of a failure being detected. This will be of type
+   *     Fault.VALIDATION_FAILED if any arguments fail validation, or type Fault.SYSTEM_ERROR if
+   *     there is a Firestore exception.
    */
   public Long waitForObject() throws CTPException {
     long startTime = System.currentTimeMillis();
@@ -76,7 +71,7 @@ public class FirestoreWait {
             + "for up to '"
             + timeout
             + "'");
-    
+
     if (newerThan != null) {
       log.info("Firestore wait. Update timestamp must be newer than '" + newerThan + "'");
     } else {
@@ -84,11 +79,16 @@ public class FirestoreWait {
     }
 
     if (contentCheckPath != null) {
-      log.info("Firestore wait. Content of '" + contentCheckPath + "' to contain '" + expectedValue + "'");
+      log.info(
+          "Firestore wait. Content of '"
+              + contentCheckPath
+              + "' to contain '"
+              + expectedValue
+              + "'");
     } else {
       log.info("Firestore wait. Not waiting on object state");
     }
-    
+
     // Validate matching path+value arguments
     if (contentCheckPath != null ^ expectedValue != null) {
       String errorMessage =
@@ -103,8 +103,8 @@ public class FirestoreWait {
     long objectUpdateTimestamp;
     do {
       objectUpdateTimestamp =
-          FirestoreService.instance().objectExists(
-              collection, key, newerThan, contentCheckPath, expectedValue);
+          FirestoreService.instance()
+              .objectExists(collection, key, newerThan, contentCheckPath, expectedValue);
       if (objectUpdateTimestamp > 0) {
         log.debug("Found object");
         found = true;
@@ -125,8 +125,7 @@ public class FirestoreWait {
 
     return objectUpdateTimestamp;
   }
-  
-  
+
   private long parseTimeoutString(String timeout) throws CTPException {
     int multiplier;
     if (timeout.endsWith("ms")) {
@@ -134,7 +133,10 @@ public class FirestoreWait {
     } else if (timeout.endsWith("s")) {
       multiplier = 1000;
     } else {
-      String errorMessage = "timeout specification ('" + timeout + "') must end with either 'ms' for milliseconds or 's' for seconds";
+      String errorMessage =
+          "timeout specification ('"
+              + timeout
+              + "') must end with either 'ms' for milliseconds or 's' for seconds";
       log.error(errorMessage);
       throw new CTPException(Fault.VALIDATION_FAILED, errorMessage);
     }

--- a/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
+++ b/src/main/java/uk/gov/ons/ctp/common/firestore/FirestoreWait.java
@@ -16,15 +16,31 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 public class FirestoreWait {
   private static final Logger log = LoggerFactory.getLogger(FirestoreWait.class);
 
+  // This is the name of the collection to search, eg, 'case'
   @NonNull private String collection;
 
+  // This is the key of the target object in the collection. eg,
+  // 'f868fcfc-7280-40ea-ab01-b173ac245da3'
   @NonNull private String key;
 
+  // This is an optional argument to specify the timestamp that the an object must have
+  // been updated after. Waiting will continue until the until the update timestamp of the
+  // object is greater than this value, or the timeout period is reached. This value is the
+  // number of milliseconds since the epoch.
   private Long newerThan;
 
+  // This is an optional path to a field whose content we check to decide if an
+  // object has been updated, eg, 'contact.forename' or 'state'. If the target object does not
+  // contain the field with the expected value then waiting will continue until it does, or the
+  // timeout is reached.
   private String contentCheckPath;
+
+  // This is the value that a field must contain if 'contentCheckPath' has been specified.
   private String expectedValue;
 
+  // This specifies how long the caller is prepared to wait for an object to appear in
+  // Firestore. This string must end with either a 'ms' suffix for milliseconds or 's' for
+  // seconds, eg, '750ms', '10s or '2.5s'.
   @NonNull private String timeout;
 
   /**
@@ -36,31 +52,15 @@ public class FirestoreWait {
    * timestamp or by the content of a named field. If both criteria are specified then both
    * conditions must be satisfied before we regard the object has having arrived in Firestore.
    *
-   * @param collection is the name of the collection to search, eg, 'case'
-   * @param key is the key of the target object in the collection. eg,
-   *     'f868fcfc-7280-40ea-ab01-b173ac245da3'
-   * @param newerThan, is an optional argument to specify the timestamp that the an object must have
-   *     been updated after. Waiting will continue until the until the update timestamp of the
-   *     object is greater than this value, or the timeout period is reached. This value is the
-   *     number of milliseconds since the epoch.
-   * @param contentCheckPath, is an optional path to a field whose content we check to decide if an
-   *     object has been updated, eg, 'contact.forename' or 'state'. If the target object does not
-   *     contain the field with the expected value then waiting will continue until it does, or the
-   *     timeout is reached.
-   * @param expectedValue, is the value that a field must contain if 'contentCheckPath' has been
-   *     specified.
-   * @param timeout specifies how long the caller is prepared to wait for an object to appear in
-   *     Firestore. This string must end with either a 'ms' suffix for milliseconds or 's' for
-   *     seconds, eg, '750ms', '10s or '2.5s'.
    * @return The update timestamp of a found object, or null if not found within the timeout.
    * @throws CTPException in the event of a failure being detected. This will be of type
    *     Fault.VALIDATION_FAILED if any arguments fail validation, or type Fault.SYSTEM_ERROR if
    *     there is a Firestore exception.
    */
   public Long waitForObject() throws CTPException {
-    long startTime = System.currentTimeMillis();
-    long timeoutMillis = parseTimeoutString(timeout);
-    long timeoutLimit = startTime + timeoutMillis;
+    final long startTime = System.currentTimeMillis();
+    final long timeoutMillis = parseTimeoutString(timeout);
+    final long timeoutLimit = startTime + timeoutMillis;
 
     log.info(
         "Firestore wait. Looking for for collection '"


### PR DESCRIPTION
# Motivation and Context
This change has moved the Firestore wait logic from the EventGenerator into the common test framework. 

This will allow cucumber tests (and potentially other code) to wait for objects to be written to Firestore. 
