### PR TITLE
Added a useful assert missing from JUnit 4

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/utility/CustomAsserts.java
+++ b/src/main/java/uk/gov/ons/ctp/common/utility/CustomAsserts.java
@@ -1,0 +1,42 @@
+package uk.gov.ons.ctp.common.utility;
+
+import static org.junit.Assert.assertTrue;
+
+/** CustomAsserts contains some asserts not available in the standard asserts */
+public class CustomAsserts {
+
+  /**
+   * This idea was borrowed from JUnit5 and allows us to assert that a piece of code will throw the
+   * expected exception, and allow us to examine the exception. This also comes in useful if we are
+   * performing asserts on multiple items in a stream, where the test would otherwise exit on the
+   * first exception.
+   *
+   * @param expected - a class object for the expected exception
+   * @param code - an arbitrary executable lambda which we expect to throw an exception
+   * @param <T> - generics boilerplate
+   * @return the thrown exception, if it happens
+   */
+  public static <T extends Throwable> T assertThrows(
+      Class<? extends Throwable> expected, Executable code) {
+    try {
+      code.run();
+    } catch (Throwable t) {
+      var message =
+          String.format(
+              "Was expecting an exception of type %s but got ^%s instead",
+              expected.getCanonicalName(), t.getClass().getCanonicalName());
+      assertTrue(message, t.getClass().isAssignableFrom(expected));
+      return (T) t;
+    }
+    throw new AssertionError(
+        String.format(
+            "Was expecting an exception of type %s but nothing was thrown",
+            expected.getCanonicalName()));
+  }
+
+  /** A functional interface for executing arbitrary code and seeing if it throws exceptions */
+  public interface Executable {
+
+    void run() throws Throwable;
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/CustomAssertsTests.java
+++ b/src/test/java/uk/gov/ons/ctp/common/CustomAssertsTests.java
@@ -1,0 +1,59 @@
+package uk.gov.ons.ctp.common;
+
+import static org.junit.Assert.*;
+import static uk.gov.ons.ctp.common.utility.CustomAsserts.assertThrows;
+
+import org.junit.Test;
+
+public class CustomAssertsTests {
+
+  @Test
+  public void assertThrowsHappilyPassesWhenExceptionThrown() {
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          throw new IllegalArgumentException();
+        });
+  }
+
+  @Test
+  public void assertThrowsWillFailIfExceptionNotThrown() {
+
+    try {
+      assertThrows(IllegalArgumentException.class, () -> {});
+    } catch (AssertionError error) {
+      assertTrue(error.getMessage().contains("but nothing was thrown"));
+    }
+  }
+
+  @Test
+  public void assertThrowsWillFailIfWrongExceptionThrown() {
+
+    try {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            throw new NullPointerException("oops");
+          });
+    } catch (AssertionError error) {
+      assertTrue(error.getMessage().contains("but got"));
+    }
+  }
+
+  @Test
+  public void assertThrowsReturnsTheThrownException() {
+
+    String message = "this is the message I will throw";
+
+    IllegalArgumentException iae =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              throw new IllegalArgumentException(message);
+            });
+
+    assertNotNull(iae);
+    assertEquals(message, iae.getMessage());
+  }
+}


### PR DESCRIPTION
# Motivation and Context

When testing that code throws an exception, sometimes the @expected annotation is not enough. For example, when performing said assert multiple times. The test will exit on the first instance of an exception. JUnit 5 provides the method Assert.assertThrows for these cases, but we do not use this library. This change adds a similar mechanism to our test framework.

# What has changed

A class and a functional interface has been added to support this. No existing code has been changed.

Unit tests covering every case have been written.

# How to test?
Tests which throw then capture various exceptions have been written. As this is a library, no other testing should be necessary.

