### PR TITLE
Cr 997

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.58</version>
+      <version>0.0.61</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>test-framework</artifactId>
-  <version>0.0.16-SNAPSHOT</version>
+  <version>0.0.16-SNAPSHOT-CR-997</version>
   <packaging>jar</packaging>
 
   <name>CTP : Census Integration Common Test Framework</name>

--- a/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -22,10 +21,8 @@ public class FixtureHelper {
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the calling class in the
-   *     classpath?
    */
-  public static <T> List<T> loadPackageFixtures(final Class<T[]> clazz) throws Exception {
+  public static <T> List<T> loadPackageFixtures(final Class<T[]> clazz) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     String callerMethodName = new Exception().getStackTrace()[1].getMethodName();
     return actuallyLoadFixtures(clazz, callerClassName, callerMethodName, null, true);
@@ -41,11 +38,8 @@ public class FixtureHelper {
    * @param clazz the type
    * @param qualifier added to file name to allow a class to have multiple forms of same type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the calling class in the
-   *     classpath?
    */
-  public static <T> List<T> loadPackageFixtures(final Class<T[]> clazz, final String qualifier)
-      throws Exception {
+  public static <T> List<T> loadPackageFixtures(final Class<T[]> clazz, final String qualifier) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     String callerMethodName = new Exception().getStackTrace()[1].getMethodName();
     return actuallyLoadFixtures(clazz, callerClassName, callerMethodName, qualifier, true);
@@ -57,10 +51,8 @@ public class FixtureHelper {
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the calling class in the
-   *     classpath?
    */
-  public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz) throws Exception {
+  public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadFixtures(clazz, callerClassName, null, null, false);
   }
@@ -74,11 +66,8 @@ public class FixtureHelper {
    * @param clazz the type
    * @param qualifier added to file name to allow a class to have multiple forms of same type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the calling class in the
-   *     classpath?
    */
-  public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz, final String qualifier)
-      throws Exception {
+  public static <T> List<T> loadMethodFixtures(final Class<T[]> clazz, final String qualifier) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     String callerMethodName = new Exception().getStackTrace()[1].getMethodName();
     return actuallyLoadFixtures(clazz, callerClassName, callerMethodName, qualifier, false);
@@ -90,10 +79,8 @@ public class FixtureHelper {
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the calling class in the
-   *     classpath?
    */
-  public static <T> List<T> loadClassFixtures(final Class<T[]> clazz) throws Exception {
+  public static <T> List<T> loadClassFixtures(final Class<T[]> clazz) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadFixtures(clazz, callerClassName, null, null, false);
   }
@@ -107,31 +94,28 @@ public class FixtureHelper {
    * @param clazz the type
    * @param qualifier added to file name to allow a class to have multiple forms of same type
    * @return the list
-   * @throws Exception failed to load - does the json file exist alongside the calling class in the
-   *     classpath?
    */
-  public static <T> List<T> loadClassFixtures(final Class<T[]> clazz, final String qualifier)
-      throws Exception {
+  public static <T> List<T> loadClassFixtures(final Class<T[]> clazz, final String qualifier) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadFixtures(clazz, callerClassName, null, qualifier, false);
   }
 
-  public static ObjectNode loadClassObjectNode() throws Exception {
+  public static ObjectNode loadClassObjectNode() {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadObjectNode(callerClassName, null, null, false);
   }
 
-  public static ObjectNode loadClassObjectNode(final String qualifier) throws Exception {
+  public static ObjectNode loadClassObjectNode(final String qualifier) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadObjectNode(callerClassName, null, qualifier, false);
   }
 
-  public static ObjectNode loadPackageObjectNode() throws Exception {
+  public static ObjectNode loadPackageObjectNode() {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadObjectNode(callerClassName, null, null, true);
   }
 
-  public static ObjectNode loadPackageObjectNode(final String qualifier) throws Exception {
+  public static ObjectNode loadPackageObjectNode(final String qualifier) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
     return actuallyLoadObjectNode(callerClassName, null, qualifier, true);
   }
@@ -147,15 +131,13 @@ public class FixtureHelper {
    * @param packageOnly true if the class and method name are not be used but instead the test class
    *     package name only
    * @return the loaded dummies of the the type T in a List
-   * @throws Exception summats went wrong
    */
   private static <T> List<T> actuallyLoadFixtures(
       final Class<T[]> clazz,
       final String callerClassName,
       final String callerMethodName,
       final String qualifier,
-      final boolean packageOnly)
-      throws Exception {
+      final boolean packageOnly) {
     List<T> dummies = null;
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
@@ -167,7 +149,7 @@ public class FixtureHelper {
       dummies = Arrays.asList(mapper.readValue(file, clazz));
     } catch (Throwable t) {
       log.debug("Problem loading fixture {} reason {}", path, t.getMessage());
-      throw new FileNotFoundException("Failed to load fixture: " + path);
+      throw new RuntimeException("Failed to load fixture: " + path);
     }
     return dummies;
   }
@@ -182,14 +164,12 @@ public class FixtureHelper {
    * @param packageOnly true if the class and method name are not be used but instead the test class
    *     package name only
    * @return the loaded dummies of the the type T in a List
-   * @throws Exception summats went wrong
    */
   private static ObjectNode actuallyLoadObjectNode(
       final String callerClassName,
       final String callerMethodName,
       final String qualifier,
-      final boolean packageOnly)
-      throws Exception {
+      final boolean packageOnly) {
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
     ObjectNode jsonNode = null;
@@ -199,7 +179,7 @@ public class FixtureHelper {
       jsonNode = (ObjectNode) mapper.readTree(file);
     } catch (Throwable t) {
       log.debug("Problem loading fixture {} reason {}", path, t.getMessage());
-      throw new FileNotFoundException("Failed to load fixture: " + path);
+      throw new RuntimeException("Failed to load fixture: " + path);
     }
     return jsonNode;
   }

--- a/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
@@ -215,7 +215,7 @@ public class FixtureHelper {
       path = path.replaceAll("\\.", "/")
         + "."
         + ((methodName != null && !packageOnly) ? (methodName + ".") : "")
-        + ((clazzName != null && !packageOnly) ? (clazzName + ".") : "")
+        + ((clazzName != null) ? (clazzName + ".") : "")
         + ((qualifier != null) ? (qualifier + ".") : "")
         + "json";
       

--- a/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
@@ -13,10 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 public class FixtureHelper {
 
   /**
-   * Find, deserialize and return List of dummy test objects from a json file This method derives
+   * Find, deserialize and return List of dummy test objects from a json file. This method derives
    * the path and file name of the json file by looking at the class and only uses the package name
-   * to derive the path to the fixture which has a file name "PackageFxiture", well as the name of
-   * the type you asked it to return.
+   * to derive the path to the fixture which has a file name "PackageFixture.", as well as the name
+   * of the type you asked it to return.
    *
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
@@ -24,15 +24,14 @@ public class FixtureHelper {
    */
   public static <T> List<T> loadPackageFixtures(final Class<T[]> clazz) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
-    String callerMethodName = new Exception().getStackTrace()[1].getMethodName();
-    return actuallyLoadFixtures(clazz, callerClassName, callerMethodName, null, true);
+    return actuallyLoadFixtures(clazz, callerClassName, null, null, true);
   }
 
   /**
-   * Find, deserialize and return List of dummy test objects from a json file This method derives
+   * Find, deserialize and return List of dummy test objects from a json file. This method derives
    * the path and file name of the json file by looking at the class and only uses the package name
-   * to derive the path to the fixture which has a file name "PackageFxiture", well as the name of
-   * the type you asked it to return. The qualifier allows for multiple PackageFixture files
+   * to derive the path to the fixture which has a file name "PackageFixture.", as well as the name
+   * of the type you asked it to return. The qualifier allows for multiple PackageFixture files
    *
    * @param <T> the type of object we expect to load and return a List of
    * @param clazz the type
@@ -41,8 +40,7 @@ public class FixtureHelper {
    */
   public static <T> List<T> loadPackageFixtures(final Class<T[]> clazz, final String qualifier) {
     String callerClassName = new Exception().getStackTrace()[1].getClassName();
-    String callerMethodName = new Exception().getStackTrace()[1].getMethodName();
-    return actuallyLoadFixtures(clazz, callerClassName, callerMethodName, qualifier, true);
+    return actuallyLoadFixtures(clazz, callerClassName, null, null, true);
   }
 
   /**


### PR DESCRIPTION
Phil and I have added support to allow tests to load fixtures at the package level as well as at the class level.
This is useful for different tests which want to share json test data files without having to copy and paste them. 
When a package fixture is loaded it expects to find the data in a file called 'PackageFixture.<Data-class-name>.json'.

This pull request is self contained so can be reviewed and merged ahead of the rest of the 997 changes.
