### PR TITLE
Cr 1047 uprn allow 13 digits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.58</version>
+      <version>0.0.62</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/common/FixtureHelper.java
@@ -122,11 +122,10 @@ public class FixtureHelper {
   /**
    * Actually does the dummy loading!
    *
-   * @param <T> the type of object we expect to load and return a List of
    * @param callerClassName name of the class that made the initial call
    * @param callerMethodName name of the method that made the initial call
    * @param qualifier added to file name to allow a class to have multiple forms of same type
-   * @return the loaded dummies of the the type T in a List
+   * @return the JSON object node
    * @throws Exception summats went wrong
    */
   private static ObjectNode actuallyLoadObjectNode(


### PR DESCRIPTION
# Motivation and Context
Update to latest common framework allowing UPRNs with 13 digits.

# What has changed
Update of framework version to 0.0.62. Fix to unrelated Javadoc error.

# Links
https://github.com/ONSdigital/census-int-common-service/pull/44
